### PR TITLE
Replace netcat image, disable dns, update make-client scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,10 @@ build-images:
 	cd tcp && make
 
 tcp-client:
-	sudo podman rm -f tcp-client && sudo podman run --name tcp-client --pod h1-pod tcp-client
+	sudo podman run -it --rm --replace --name tcp-client --pod h1-pod tcp-client
+
+netcat-client:
+	sudo podman run -it --rm --replace --name netcat-client --pod h1-pod docker.io/gophernet/netcat -v 10.1.1.10 12345
+
+iperf-client:
+	sudo podman run -it --rm --replace --name iperf-client --pod h1-pod docker.io/networkstatic/iperf3 -c 10.1.1.10 -p 12345 -t 30

--- a/scripts/switch_container/build.sh
+++ b/scripts/switch_container/build.sh
@@ -9,30 +9,30 @@ ARGS=""
 # IMG="docker.io/networkstatic/iperf3"
 # ARGS="-s -p 12345"
 
-# IMG="docker.io/subfuzion/netcat"
-# ARGS="-vl 12345"
+# IMG="docker.io/gophernet/netcat"
+# ARGS="-v -l -p 12345"
 
 # Host 1
 printf "\n-----Creating host 1-----\n"
-sudo podman network create --driver bridge --opt isolate=1 --interface-name h1-br --gateway 10.1.1.10 --subnet 10.1.1.0/24 h1-net
+sudo podman network create --driver bridge --opt isolate=1 --disable-dns --interface-name h1-br --gateway 10.1.1.10 --subnet 10.1.1.0/24 h1-net
 sudo podman pod create --name h1-pod --network h1-net --mac-address 08:00:00:00:01:01 --ip 10.1.1.1
 sudo podman run --detach --privileged --name h1 --pod h1-pod --cap-add NET_ADMIN $IMG $ARGS
 
 # Host 2
 printf "\n-----Creating host 2-----\n"
-sudo podman network create --driver bridge --opt isolate=1 --interface-name h2-br --gateway 10.2.2.20 --route 10.1.1.0/24,10.2.2.20 --subnet 10.2.2.0/24 h2-net
+sudo podman network create --driver bridge --opt isolate=1 --disable-dns --interface-name h2-br --gateway 10.2.2.20 --route 10.1.1.0/24,10.2.2.20 --subnet 10.2.2.0/24 h2-net
 sudo podman pod create --name h2-pod --network h2-net --mac-address 08:00:00:00:02:02 --ip 10.2.2.2
 sudo podman run --detach --privileged --name h2 --pod h2-pod --cap-add NET_ADMIN $IMG $ARGS
 
 # Host 3
 printf "\n-----Creating host 3-----\n"
-sudo podman network create --driver bridge  --opt isolate=1 --interface-name h3-br --gateway 10.3.3.30 --route 10.1.1.0/24,10.3.3.30 --subnet 10.3.3.0/24 h3-net
+sudo podman network create --driver bridge  --opt isolate=1 --disable-dns --interface-name h3-br --gateway 10.3.3.30 --route 10.1.1.0/24,10.3.3.30 --subnet 10.3.3.0/24 h3-net
 sudo podman pod create --name h3-pod --network h3-net --mac-address 08:00:00:00:03:03 --ip 10.3.3.3
 sudo podman run --detach --privileged --name h3 --pod h3-pod --cap-add NET_ADMIN $IMG $ARGS
 
 # Host 4
 printf "\n-----Creating host 4-----\n"
-sudo podman network create --driver bridge --opt isolate=1 --interface-name h4-br --gateway 10.4.4.40 --route 10.1.1.0/24,10.4.4.40 --subnet 10.4.4.0/24 h4-net
+sudo podman network create --driver bridge --opt isolate=1 --disable-dns --interface-name h4-br --gateway 10.4.4.40 --route 10.1.1.0/24,10.4.4.40 --subnet 10.4.4.0/24 h4-net
 sudo podman pod create --name h4-pod --network h4-net --mac-address 08:00:00:00:04:04 --ip 10.4.4.4
 sudo podman run --detach --privileged --name h4 --pod h4-pod --cap-add NET_ADMIN $IMG $ARGS
 


### PR DESCRIPTION
The previous netcat container was not working properly, so I replaced the image. That netcat server was making DNS requests for some reasons, so I thought it also makes sense to disable DNS for the container networks, since that feature is not needed in this project.

Updated the `tcp-client` makefile target to properly stop/replace the previous container, added `netcat-client` and `iperf-client` targets to also allow testing.