### PR TITLE
make: specify phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MIGRATION_SCRIPT_PATH := ./scripts/switch_container/cr.sh
 
 all: compile net control
 
-net: 
+net:
 	cd scripts/switch_container && make
 
 compile:
@@ -33,3 +33,5 @@ netcat-client:
 
 iperf-client:
 	sudo podman run -it --rm --replace --name iperf-client --pod h1-pod docker.io/networkstatic/iperf3 -4 -c 10.1.1.10 -p 12345 -t 30
+
+.PHONY: all net compile control clean build-images tcp-client netcat-client iperf-client

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -2,3 +2,5 @@ all: run
 
 run:
 	./controller.py
+
+.PHONY: all run

--- a/load_balancer/Makefile
+++ b/load_balancer/Makefile
@@ -6,7 +6,7 @@ all: run
 
 run: compile
 
-run_switches:	
+run_switches:
 	sudo simple_switch_grpc \
 		-i 1@s1-eth1 \
 		-i 2@s1-eth2 \
@@ -78,4 +78,5 @@ stop:
 clean: stop
 	rm -f *.pcap
 	rm -rf $(BUILD_DIR) $(PCAP_DIR) $(LOG_DIR)
-	
+
+.PHONY: all run run_switches compile dirs stop clean

--- a/tcp/Makefile
+++ b/tcp/Makefile
@@ -6,7 +6,7 @@ client-bin:: client.c
 server-bin:: server.c
 	gcc -Wall -o server server.c
 
-server-container:: Containerfile.server 
+server-container:: Containerfile.server
 	sudo podman build -t tcp-server -f Containerfile.server .
 
 client-container:: Containerfile.client
@@ -15,3 +15,5 @@ client-container:: Containerfile.client
 clean:
 	rm -rf client server
 	sudo podman rmi tcp-server tcp-client
+
+.PHONY: all client-bin server-bin server-container clean


### PR DESCRIPTION
When the makefile target is not associated with a file, we need to specify this target as phony to ensure that it will always execute.