### PR TITLE
Update migration script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+SHELL := /bin/bash
+MIGRATION_SCRIPT_PATH := ./scripts/switch_container/cr.sh
+
 all: compile net control
 
 net: 
@@ -8,6 +11,13 @@ compile:
 
 control:
 	cd controller && sleep 2 && make
+
+migrate:
+	@if [ "${SOURCE}" = "" ] || [ "${TARGET}" = "" ]; then \
+		echo "Usage: make migrate SOURCE=x TARGET=y"; \
+	else \
+		$(MIGRATION_SCRIPT_PATH) ${SOURCE} ${TARGET}; \
+	fi
 
 clean:
 	cd scripts/switch_container && make clean

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ tcp-client:
 	sudo podman run -it --rm --replace --name tcp-client --pod h1-pod tcp-client
 
 netcat-client:
-	sudo podman run -it --rm --replace --name netcat-client --pod h1-pod docker.io/gophernet/netcat -v 10.1.1.10 12345
+	sudo podman run -it --rm --replace --name netcat-client --pod h1-pod docker.io/subfuzion/netcat -4 -v 10.1.1.10 12345
 
 iperf-client:
-	sudo podman run -it --rm --replace --name iperf-client --pod h1-pod docker.io/networkstatic/iperf3 -c 10.1.1.10 -p 12345 -t 30
+	sudo podman run -it --rm --replace --name iperf-client --pod h1-pod docker.io/networkstatic/iperf3 -4 -c 10.1.1.10 -p 12345 -t 30

--- a/load_balancer/s1-runtime.json
+++ b/load_balancer/s1-runtime.json
@@ -33,7 +33,7 @@
             "action_name": "MyIngress.set_ecmp_select",
             "action_params": {
                 "ecmp_base": 1,
-                "ecmp_count": 1
+                "ecmp_count": 2
             }
         },
         {

--- a/scripts/edit_files_img.py
+++ b/scripts/edit_files_img.py
@@ -23,47 +23,58 @@ def check_crit_installed():
             "Please install CRIU and ensure 'crit' is in your PATH."
         )
         sys.exit(1)
-
-
+        
 def update_src_addr(file_path, old_addr, new_addr):
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        temp_file_path = temp_file.name
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file_path = temp_file.name
 
-    subprocess.run(
-        f"crit decode -i {file_path} --pretty > {temp_file_path}",
-        shell=True,
-        check=True,
-    )
+        # Decode the image
+        subprocess.run(
+            f"crit decode -i {file_path} --pretty > {temp_file_path}",
+            shell=True,
+            check=True,
+        )
 
-    with open(temp_file_path, "r") as file:
-        data = json.load(file)
+        with open(temp_file_path, "r") as file:
+            data = json.load(file)
 
-    updated = False
-    for entry in data.get("entries", []):
-        if entry.get("type") == "INETSK":
-            src_addrs = entry.get("isk", {}).get("src_addr")
-            if old_addr in src_addrs:
-                entry["isk"]["src_addr"] = [new_addr]
-                print(
-                    f"Updated src_addr from {old_addr} to "
-                    f"{new_addr} in {file_path}"
-                )
-                updated = True
+        updated = False
+        for entry in data.get("entries", []):
+            if entry.get("type") == "INETSK":
+                src_addrs = entry.get("isk", {}).get("src_addr")
+                if old_addr in src_addrs:
+                    entry["isk"]["src_addr"] = [new_addr]
+                    print(
+                        f"Updated src_addr from {old_addr} to "
+                        f"{new_addr} in {file_path}"
+                    )
+                    updated = True
 
-    if not updated:
-        print(f"Error: could not find src_addr {old_addr} in {file_path}")
-        return
+        if not updated:
+            print(f"Error: could not find src_addr {old_addr} in {file_path}")
+            raise Exception(f"Error: could not find src_addr {old_addr} in {file_path}")
 
-    with open(temp_file_path, "w") as file:
-        json.dump(data, file, indent=4)
+        with open(temp_file_path, "w") as file:
+            json.dump(data, file, indent=4)
 
-    subprocess.run(
-        f"crit encode -i {temp_file_path} -o {file_path}",
-        shell=True,
-        check=True,
-    )
+        # Encode the updated data back into the file
+        subprocess.run(
+            f"crit encode -i {temp_file_path} -o {file_path}",
+            shell=True,
+            check=True,
+        )
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        # Dump the current data to a file in /tmp for debugging
+        error_dump_path = "/tmp/decoded_image.json"
+        with open(error_dump_path, "w") as error_file:
+            json.dump(data, error_file, indent=4)
+        print(f"Decoded image dumped to {error_dump_path} for debugging.")
+    finally:
+        if os.path.exists(temp_file_path):
+            os.remove(temp_file_path)
 
-    os.remove(temp_file_path)
 
 
 def process_directory(input_dir, old_addr, new_addr):

--- a/scripts/edit_files_img.py
+++ b/scripts/edit_files_img.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
 import json
-import sys
-import subprocess
-import tempfile
 import os
-import tarfile
 import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
 
 
 def check_crit_installed():
@@ -23,7 +23,8 @@ def check_crit_installed():
             "Please install CRIU and ensure 'crit' is in your PATH."
         )
         sys.exit(1)
-        
+
+
 def update_src_addr(file_path, old_addr, new_addr):
     try:
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
@@ -53,7 +54,9 @@ def update_src_addr(file_path, old_addr, new_addr):
 
         if not updated:
             print(f"Error: could not find src_addr {old_addr} in {file_path}")
-            raise Exception(f"Error: could not find src_addr {old_addr} in {file_path}")
+            raise Exception(
+                f"Error: could not find src_addr {old_addr} in {file_path}"
+            )
 
         with open(temp_file_path, "w") as file:
             json.dump(data, file, indent=4)
@@ -74,7 +77,6 @@ def update_src_addr(file_path, old_addr, new_addr):
     finally:
         if os.path.exists(temp_file_path):
             os.remove(temp_file_path)
-
 
 
 def process_directory(input_dir, old_addr, new_addr):

--- a/scripts/switch_container/build.sh
+++ b/scripts/switch_container/build.sh
@@ -7,10 +7,10 @@ IMG="tcp-server"
 ARGS=""
 
 # IMG="docker.io/networkstatic/iperf3"
-# ARGS="-s -p 12345"
+# ARGS="-4 -s -p 12345"
 
-# IMG="docker.io/gophernet/netcat"
-# ARGS="-v -l -p 12345"
+# IMG="docker.io/subfuzion/netcat"
+# ARGS="-4 -v -l -p 12345"
 
 # Host 1
 printf "\n-----Creating host 1-----\n"

--- a/scripts/switch_container/cr.sh
+++ b/scripts/switch_container/cr.sh
@@ -1,26 +1,47 @@
+#!/bin/bash
+
+# Check if exactly two arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <source_idx> <target_idx>"
+    exit 1
+fi
+
+# Assigning arguments to variables
+SOURCE_IDX=$1
+TARGET_IDX=$2
+
 CHECKPOINT_DIR=/tmp/checkpoints
 CHECKPOINT_PATH=$CHECKPOINT_DIR/checkpoint.tar
 
-SOURCE_IDX=3
 SOURCE_HOST=h$SOURCE_IDX
 SOURCE_IP=10.$SOURCE_IDX.$SOURCE_IDX.$SOURCE_IDX
 
-TARGET_IDX=4
 TARGET_HOST=h$TARGET_IDX
 TARGET_IP=10.$TARGET_IDX.$TARGET_IDX.$TARGET_IDX
 TARGET_MAC=08:00:00:00:0$TARGET_IDX:0$TARGET_IDX
 
+# Creating checkpoint directory
 sudo mkdir -p $CHECKPOINT_DIR
 
+# Checkpoint the source container
 sudo podman container checkpoint --export $CHECKPOINT_PATH --compress none --keep --tcp-established $SOURCE_HOST
 sudo podman rm -f $SOURCE_HOST
 
+# Edit the checkpoint files with new IP
 sudo /home/p4/p4containerflow/scripts/edit_files_img.py $CHECKPOINT_PATH $SOURCE_IP $TARGET_IP
 
+# Kill and remove the target container
+sudo podman container kill ${TARGET_HOST}
+sudo podman container rm -f ${TARGET_HOST}
+
+# Restore the container with new settings
 sudo podman container restore --import $CHECKPOINT_PATH --keep --tcp-established --ignore-static-ip --ignore-static-mac --pod ${TARGET_HOST}-pod
+
+# Rename the restored container
 # --name cannot be used with --tcp-established on restore
 sudo podman rename $SOURCE_HOST $TARGET_HOST
 
+# Update the node information
 curl -X POST http://127.0.0.1:5000/update_node \
     -H "Content-Type: application/json" \
     -d "{\"old_ipv4\":\"${SOURCE_IP}\", \"new_ipv4\":\"${TARGET_IP}\", \"dmac\":\"${TARGET_MAC}\", \"eport\":\"${TARGET_IDX}\"}"


### PR DESCRIPTION
- Update migration script to take in `SOURCE` and `TARGET` arguments - use `make migrate SOURCE=<> TARGET=<>` to perform end-to-end container migration
- Revert `netcat` to the previous image from [subfuzion](docker.io/subfuzion/netcat), since the other implementation doesn't support ipv4
- Add `-4` option to `iperf3` and `netcat` to only use `ipv4`
- Change the `edit_files_image.py` script to dump the image in `json` in case there is an error -> easier debugging
- Change the node count to 2 in the load balancer again, to allow load balancing behavior (this was previously one to make debugging easier, the load balancer would only target the `10.2.2.2` node)

I tested the migration using the simple tcp-server and iperf3 -> the migration seems to work correctly with one client, the connection immediately resumes.
Using netcat however, there is an error `nc: polling error: Interrupted system call` which I assume is caused by the checkpointing operation.

However, there were issues with migrating twice:

```
(00.001439) Error (compel/src/lib/infect.c:263): Unseizable non-zombie 119973 found, state S, err -1/10
(00.001445) net: Unlock network
(00.001447) Unfreezing tasks into 1
(00.001448) 	Unseizing 119973 into 1
(00.001449) Error (compel/src/lib/infect.c:418): Unable to detach from 119973: No such process
(00.001452) Error (criu/cr-dump.c:2098): Dumping FAILED.
```

Full log for future reference:
```
(00.000000) Unable to get $HOME directory, local configuration file will not be used.
(00.000015) Version: 3.19 (gitid v3.19)
(00.000017) Running on p4 Linux 6.8.0-36-generic #36-Ubuntu SMP PREEMPT_DYNAMIC Mon Jun 10 10:49:14 UTC 2024 x86_64
(00.000018) Would overwrite RPC settings with values from /etc/criu/runc.conf
(00.000024) Loaded kdat cache from /run/criu.kdat
(00.000033) Hugetlb size 2 Mb is supported but cannot get dev's number
(00.000636) Will dump/restore TCP connections
(00.000643) ========================================
(00.000649) Dumping processes (pid: 119973 comm: server)
(00.000650) ========================================
(00.000651) rlimit: RLIMIT_NOFILE unlimited for self
(00.000654) Running pre-dump scripts
(00.000654) 	RPC
(00.000901) irmap: Searching irmap cache in work dir
(00.000911) No irmap-cache image
(00.000912) irmap: Searching irmap cache in parent
(00.000913) No parent images directory provided
(00.000914) irmap: No irmap cache
(00.001136) cpu: x86_family 6 x86_vendor_id GenuineIntel x86_model_id Intel(R) Core(TM) i5-14600KF
(00.001138) cpu: fpu: x87 FPU will use FXSAVE
(00.001139) cpu: fpu:1 fxsr:1 xsave:0 xsaveopt:0 xsavec:0 xgetbv1:0 xsaves:0
(00.001206) cg-prop: Parsing controller "cpu"
(00.001207) cg-prop: 	Strategy "replace"
(00.001208) cg-prop: 	Property "cpu.shares"
(00.001208) cg-prop: 	Property "cpu.cfs_period_us"
(00.001209) cg-prop: 	Property "cpu.cfs_quota_us"
(00.001209) cg-prop: 	Property "cpu.rt_period_us"
(00.001210) cg-prop: 	Property "cpu.rt_runtime_us"
(00.001210) cg-prop: Parsing controller "memory"
(00.001210) cg-prop: 	Strategy "replace"
(00.001211) cg-prop: 	Property "memory.limit_in_bytes"
(00.001211) cg-prop: 	Property "memory.memsw.limit_in_bytes"
(00.001212) cg-prop: 	Property "memory.swappiness"
(00.001212) cg-prop: 	Property "memory.soft_limit_in_bytes"
(00.001213) cg-prop: 	Property "memory.move_charge_at_immigrate"
(00.001213) cg-prop: 	Property "memory.oom_control"
(00.001213) cg-prop: 	Property "memory.use_hierarchy"
(00.001214) cg-prop: 	Property "memory.kmem.limit_in_bytes"
(00.001214) cg-prop: 	Property "memory.kmem.tcp.limit_in_bytes"
(00.001215) cg-prop: Parsing controller "cpuset"
(00.001215) cg-prop: 	Strategy "replace"
(00.001215) cg-prop: 	Property "cpuset.cpus"
(00.001216) cg-prop: 	Property "cpuset.mems"
(00.001216) cg-prop: 	Property "cpuset.memory_migrate"
(00.001216) cg-prop: 	Property "cpuset.cpu_exclusive"
(00.001217) cg-prop: 	Property "cpuset.mem_exclusive"
(00.001217) cg-prop: 	Property "cpuset.mem_hardwall"
(00.001218) cg-prop: 	Property "cpuset.memory_spread_page"
(00.001218) cg-prop: 	Property "cpuset.memory_spread_slab"
(00.001218) cg-prop: 	Property "cpuset.sched_load_balance"
(00.001219) cg-prop: 	Property "cpuset.sched_relax_domain_level"
(00.001219) cg-prop: Parsing controller "blkio"
(00.001220) cg-prop: 	Strategy "replace"
(00.001220) cg-prop: 	Property "blkio.weight"
(00.001220) cg-prop: Parsing controller "freezer"
(00.001221) cg-prop: 	Strategy "replace"
(00.001221) cg-prop: Parsing controller "perf_event"
(00.001222) cg-prop: 	Strategy "replace"
(00.001222) cg-prop: Parsing controller "net_cls"
(00.001222) cg-prop: 	Strategy "replace"
(00.001223) cg-prop: 	Property "net_cls.classid"
(00.001223) cg-prop: Parsing controller "net_prio"
(00.001224) cg-prop: 	Strategy "replace"
(00.001224) cg-prop: 	Property "net_prio.ifpriomap"
(00.001224) cg-prop: Parsing controller "pids"
(00.001225) cg-prop: 	Strategy "replace"
(00.001225) cg-prop: 	Property "pids.max"
(00.001226) cg-prop: Parsing controller "devices"
(00.001226) cg-prop: 	Strategy "replace"
(00.001226) cg-prop: 	Property "devices.list"
(00.001235) Preparing image inventory (version 1)
(00.001245) Add pid ns 1 pid 120263
(00.001250) Add net ns 2 pid 120263
(00.001253) Add ipc ns 3 pid 120263
(00.001256) Add uts ns 4 pid 120263
(00.001258) Add time ns 5 pid 120263
(00.001263) Add mnt ns 6 pid 120263
(00.001266) Add user ns 7 pid 120263
(00.001269) Add cgroup ns 8 pid 120263
(00.001269) cg: Dumping cgroups for thread 120263
(00.001276) cg:  `- New css ID 1
(00.001277) cg:     `- [] -> [/system.slice/ssh.service] [0]
(00.001280) cg: Set 1 is criu one
(00.001294) Detected cgroup V2 freezer
(00.001294) freezing processes: 100000 attempts with 100 ms steps
(00.001298) cgroup.freeze=0
(00.001307) cgroup.freeze=1
(00.001315) freezing processes: 0 attempts done
(00.001439) Error (compel/src/lib/infect.c:263): Unseizable non-zombie 119973 found, state S, err -1/10
(00.001445) net: Unlock network
(00.001447) Unfreezing tasks into 1
(00.001448) 	Unseizing 119973 into 1
(00.001449) Error (compel/src/lib/infect.c:418): Unable to detach from 119973: No such process
(00.001452) Error (criu/cr-dump.c:2098): Dumping FAILED.

```
