### PR TITLE
examples: enable debugging in shell scripts

### DIFF
--- a/examples/host_containers/build.sh
+++ b/examples/host_containers/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -xe
+
 BUILD_DIR=../../load_balancer/build
 PCAP_DIR=../../load_balancer/pcaps
 LOG_DIR=../../load_balancer/logs
@@ -93,7 +96,7 @@ printf "Interface: %s\n" $iface
     sudo ethtool -K $iface tx off
     sudo ethtool -K $iface rx off
     sudo ethtool -K $iface sg off
-    
+
     # Set the MTU of these interfaces to be larger than default of
     # 1500 bytes, so that P4 behavioral-model testing can be done
     # on jumbo frames.

--- a/examples/host_containers/cr.sh
+++ b/examples/host_containers/cr.sh
@@ -6,6 +6,8 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
+set -xe
+
 # Assigning arguments to variables
 SOURCE_IDX=$1
 TARGET_IDX=$2

--- a/examples/process_migration/build.sh
+++ b/examples/process_migration/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -xe
+
 BUILD_DIR=../../load_balancer/build
 PCAP_DIR=../../load_balancer/pcaps
 LOG_DIR=../../load_balancer/logs
@@ -29,7 +31,7 @@ for iface in "${interfaces[@]}"; do
     sudo ethtool -K $iface tx off
     sudo ethtool -K $iface rx off
     sudo ethtool -K $iface sg off
-    
+
     # Set the MTU of these interfaces to be larger than default of
     # 1500 bytes, so that P4 behavioral-model testing can be done
     # on jumbo frames.
@@ -45,7 +47,7 @@ sudo ip link set dev s2-eth1 address 00:00:00:02:01:00
 sudo ip addr add 10.0.2.20/24 dev s2-eth1
 sudo ip link set dev s2-eth2 address 00:00:00:02:02:00
 sudo ip link set dev s3-eth1 address 00:00:00:03:01:00
-sudo ip addr add 10.0.3.30/24 dev s3-eth1 
+sudo ip addr add 10.0.3.30/24 dev s3-eth1
 sudo ip link set dev s3-eth2 address 00:00:00:03:02:00
 sudo ip link set dev s4-eth1 address 00:00:00:04:01:00
 sudo ip addr add 10.0.4.40/24 dev s4-eth1

--- a/examples/process_migration/cr.sh
+++ b/examples/process_migration/cr.sh
@@ -6,6 +6,8 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
+set -xe
+
 # Assigning arguments to variables
 SOURCE_IDX=$1
 TARGET_IDX=$2

--- a/examples/switch_container/build.sh
+++ b/examples/switch_container/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -xe
+
 NUM_HOSTS=4
 
 # Container image and arguments
@@ -52,7 +54,7 @@ printf "Interface: %s\n" $iface
     sudo ethtool -K $iface tx off
     sudo ethtool -K $iface rx off
     sudo ethtool -K $iface sg off
-    
+
     # Set the MTU of these interfaces to be larger than default of
     # 1500 bytes, so that P4 behavioral-model testing can be done
     # on jumbo frames.

--- a/examples/switch_container/cr.sh
+++ b/examples/switch_container/cr.sh
@@ -6,6 +6,8 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
+set -xe
+
 # Assigning arguments to variables
 SOURCE_IDX=$1
 TARGET_IDX=$2


### PR DESCRIPTION
This pull request sets the following two options for the build and c/r shell scripts:

 - `-x`: enables debugging mode where each command and its arguments are printed to the standard error (stderr) before execution

 - `-e`: exit immediately if any command returns a non-zero exit status