### PR TITLE
Extend manifests to work properly with kubeadm

### DIFF
--- a/examples/container_migration_in_kubernetes/README.md
+++ b/examples/container_migration_in_kubernetes/README.md
@@ -66,6 +66,7 @@ kubectl get service http-server
 ```
 
 ### 6. Apply the RBAC configuration to allow the checkpoint plugin to create a checkpoint (optional if your config already allows this):
+First, replace `<your_machine_name>` with the name of your machine. Then, run:
 ```
 kubectl apply -f manifests/checkpoint-rbac.yaml
 ```

--- a/examples/container_migration_in_kubernetes/README.md
+++ b/examples/container_migration_in_kubernetes/README.md
@@ -14,7 +14,7 @@ checkpointing feature in Kubernetes, please refer to the following pages:
 
 ## Running the example
 
-1. Install CNI Plugins on each node
+### 1. Install CNI Plugins on each node
 
 The CNI configuration file is expected to be present as `/etc/cni/net.d/10-kuberouter.conf`
 ```
@@ -35,24 +35,24 @@ sudo mkdir -p /opt/cni/bin
 sudo cp bin/* /opt/cni/bin/
 ```
 
-2. Deploy daemonset
+### 2. Initialize the Kubernetes cluster using kubeadm (optional):
+```
+sudo kubeadm init --pod-network-cidr=10.85.0.0/16 --cri-socket=unix:///var/run/crio/crio.sock
+```
+
+### 3. Untaint the master node to allow pods to be scheduled (optional, assuming a single node cluster):
+```
+kubectl taint nodes --all node-role.kubernetes.io/master-
+kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+```
+
+
+### 4. Deploy daemonset
 ```
 kubectl apply -f manifests/kube-router-daemonset.yaml
 ```
 
-3. Setup a local container registry
-
-```
-cd local-registry/
-./generate-password.sh <user>
-./generate-certificates.sh <hostname>
-./trust-certificates.sh
-./run.sh
-
-buildah login <hostname>:5000
-```
-
-3. Deploy an HTTP server
+### 5. Deploy an HTTP server
 
 ```
 kubectl apply -f manifests/http-server-deployment.yaml
@@ -65,25 +65,42 @@ kubectl get deployments
 kubectl get service http-server
 ```
 
-4. Install kubectl checkpoint plugin
+### 6. Apply the RBAC configuration to allow the checkpoint plugin to create a checkpoint (optional if your config already allows this):
+```
+kubectl apply -f manifests/checkpoint-rbac.yaml
+```
+
+### 7. Setup a local container registry (optional, you can use any other registry)
+
+```
+cd local-registry/
+./generate-password.sh <user>
+./generate-certificates.sh <hostname>
+./trust-certificates.sh
+./run.sh
+
+buildah login <hostname>:5000
+```
+
+### 8. Install the kubectl checkpoint plugin
 
 ```
 sudo cp kubectl-plugin/kubectl-checkpoint /usr/local/bin/
 ```
 
-5. Enable checkpoint/restore with established TCP connections
+### 9. Enable checkpoint/restore with established TCP connections
 ```
 sudo mkdir -p /etc/criu/
 echo "tcp-established" | sudo tee -a /etc/criu/runc.conf
 ```
 
-6. Create container checkpoint
+### 10. Create container checkpoint
 
 ```
 kubectl checkpoint <pod> <container>
 ```
 
-7. Build a checkpoint OCI image and push to registry
+### 11. Build a checkpoint OCI image and push to registry
 
 ```
 build-image/build-image.sh -a <annotations-file> -c <checkpoint-path> -i <hostname>:5000/<image>:<tag>
@@ -91,7 +108,7 @@ build-image/build-image.sh -a <annotations-file> -c <checkpoint-path> -i <hostna
 buildah push <hostname>:5000/<image>:<tag>
 ```
 
-7. Restore container from checkpoint image
+### 12. Restore container from checkpoint image
 
 Replace the container `image` filed in `http-server-deployment.yaml` with the
 checkpoint OCI image `<hostname>:5000/<image>:<tag>` and apply the new deployment.

--- a/examples/container_migration_in_kubernetes/kubectl-plugin/kubectl-checkpoint
+++ b/examples/container_migration_in_kubernetes/kubectl-plugin/kubectl-checkpoint
@@ -13,7 +13,7 @@ elif [ "$#" -ne 3 ]; then
 	exit 1
 fi
 
-curl --insecure \
+sudo curl --insecure \
 	--cert /var/lib/kubelet/pki/kubelet-client-current.pem \
 	--key /var/lib/kubelet/pki/kubelet-client-current.pem \
 	-X POST \

--- a/examples/container_migration_in_kubernetes/manifests/checkpoint-rbac.yaml
+++ b/examples/container_migration_in_kubernetes/manifests/checkpoint-rbac.yaml
@@ -25,7 +25,8 @@ roleRef:
   name: checkpoint-role
 subjects:
   - kind: User
-    name: system:node:codingbeast
+    # Replace <your_machine_name> with the name of your machine
+    name: system:node:<your_machine_name>
     apiGroup: rbac.authorization.k8s.io
 
 ---

--- a/examples/container_migration_in_kubernetes/manifests/checkpoint-rbac.yaml
+++ b/examples/container_migration_in_kubernetes/manifests/checkpoint-rbac.yaml
@@ -1,4 +1,6 @@
-# checkpoint-rbac.yaml
+# When running the `kubectl checkpoint` command, you may see the following error:
+# Forbidden (user=system:node:<your_machine_name>, verb=create, resource=nodes, subresource=checkpoint)
+# This ClusterRole allows the create verb on the nodes resource and the nodes/checkpoint subresource.
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/examples/container_migration_in_kubernetes/manifests/checkpoint-rbac.yaml
+++ b/examples/container_migration_in_kubernetes/manifests/checkpoint-rbac.yaml
@@ -1,0 +1,41 @@
+# checkpoint-rbac.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: checkpoint-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "get", "watch", "create"]
+  - apiGroups: [""]
+    resources: ["nodes/checkpoint"]
+    verbs: ["create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: checkpoint-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: checkpoint-role
+subjects:
+  - kind: User
+    name: system:node:codingbeast
+    apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-router-checkpoint-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: checkpoint-role
+subjects:
+  - kind: ServiceAccount
+    name: kube-router
+    namespace: kube-system

--- a/examples/container_migration_in_kubernetes/manifests/kube-router-daemonset.yaml
+++ b/examples/container_migration_in_kubernetes/manifests/kube-router-daemonset.yaml
@@ -17,6 +17,7 @@ data:
              "type":"bridge",
              "bridge":"kube-bridge",
              "isDefaultGateway":true,
+             "hairpinMode":true,
              "ipam":{
                 "type":"host-local"
              }
@@ -27,110 +28,203 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kube-router
-  namespace: kube-system
   labels:
     k8s-app: kube-router
+    tier: node
+  name: kube-router
+  namespace: kube-system
 spec:
   selector:
     matchLabels:
       k8s-app: kube-router
+      tier: node
   template:
     metadata:
       labels:
         k8s-app: kube-router
+        tier: node
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: kube-router
+      serviceAccount: kube-router
       containers:
-      - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router
-        args:
-          - "--run-router=true"
-          - "--run-firewall=true"
-          - "--run-loadbalancer=true"
-          - "--run-service-proxy=true"
-          - "--bgp-graceful-restart=true"
-          - "--kubeconfig=/var/lib/kube-router/kubeconfig"
-        securityContext:
-          privileged: true
-        imagePullPolicy: Always
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: KUBE_ROUTER_CNI_CONF_FILE
-          value: /etc/cni/net.d/10-kuberouter.conflist
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 20244
-          initialDelaySeconds: 10
-          periodSeconds: 3
-        volumeMounts:
-        - name: lib-modules
-          mountPath: /lib/modules
-          readOnly: true
-        - name: cni-conf-dir
-          mountPath: /etc/cni/net.d
-        - name: kubeconfig
-          mountPath: /var/lib/kube-router/kubeconfig
-          readOnly: true
-        - name: xtables-lock
-          mountPath: /run/xtables.lock
-          readOnly: false
+        - name: kube-router
+          image: docker.io/cloudnativelabs/kube-router
+          imagePullPolicy: Always
+          args:
+            - --run-router=true
+            - --run-firewall=true
+            - --run-loadbalancer=true
+            - --run-service-proxy=true
+            - --bgp-graceful-restart=true
+            - --kubeconfig=/var/lib/kube-router/kubeconfig
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBE_ROUTER_CNI_CONF_FILE
+              value: /etc/cni/net.d/10-kuberouter.conflist
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 20244
+            initialDelaySeconds: 10
+            periodSeconds: 3
+          resources:
+            requests:
+              cpu: 250m
+              memory: 250Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: cni-conf-dir
+              mountPath: /etc/cni/net.d
+            - name: kubeconfig
+              mountPath: /var/lib/kube-router
+              readOnly: true
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+              readOnly: false
       initContainers:
-      - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router
-        imagePullPolicy: Always
-        command:
-        - /bin/sh
-        - -c
-        - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
-            if [ -f /etc/cni/net.d/*.conf ]; then
+        - name: install-cni
+          image: docker.io/cloudnativelabs/kube-router
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -c
+            - set -e -x;
+              if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+              if [ -f /etc/cni/net.d/*.conf ]; then
               rm -f /etc/cni/net.d/*.conf;
-            fi;
-            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
-            cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
-          fi;
-          if [ -x /usr/local/bin/cni-install ]; then
-            /usr/local/bin/cni-install;
-          fi;
-        volumeMounts:
-        - name: cni-conf-dir
-          mountPath: /etc/cni/net.d
-        - name: kube-router-cfg
-          mountPath: /etc/kube-router
-        - name: host-opt
-          mountPath: /opt
+              fi;
+              TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+              cp /etc/kube-router/cni-conf.json ${TMP};
+              mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
+              fi;
+              if [ -x /usr/local/bin/cni-install ]; then
+              /usr/local/bin/cni-install;
+              fi;
+          volumeMounts:
+            - name: cni-conf-dir
+              mountPath: /etc/cni/net.d
+            - name: kube-router-cfg
+              mountPath: /etc/kube-router
+            - name: host-opt
+              mountPath: /opt
       hostNetwork: true
       hostPID: true
       tolerations:
-      - effect: NoSchedule
-        operator: Exists
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
       volumes:
-      - name: lib-modules
-        hostPath:
-          path: /lib/modules
-      - name: cni-conf-dir
-        hostPath:
-          path: /etc/cni/net.d
-      - name: kube-router-cfg
-        configMap:
-          name: kube-router-cfg
-      - name: kubeconfig
-        hostPath:
-          path: /var/lib/kube-router/kubeconfig
-      - name: xtables-lock
-        hostPath:
-          path: /run/xtables.lock
-          type: FileOrCreate
-      - name: host-opt
-        hostPath:
-          path: /opt
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: cni-conf-dir
+          hostPath:
+            path: /etc/cni/net.d
+        - name: kube-router-cfg
+          configMap:
+            name: kube-router-cfg
+        - name: kubeconfig
+          configMap:
+            name: kube-proxy
+            items:
+              - key: kubeconfig.conf
+                path: kubeconfig
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        - name: host-opt
+          hostPath:
+            path: /opt
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - services
+      - nodes
+      - endpoints
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+  - kind: ServiceAccount
+    name: kube-router
+    namespace: kube-system


### PR DESCRIPTION
**Add ServiceAccount and ClusterRoleBinding to the daemonset manifest**
When initializing a local single-node Kubernetes cluster with kubeadm, kube-router is not able to access certaub resources and fails to start. This PR adds a ServiceAccount and a ClusterRoleBinding to the kube-router manifest.
This manifest comes from the [official kube-router repository](https://github.com/cloudnativelabs/kube-router/blob/master/daemonset/kubeadm-kuberouter-all-features.yaml)

**Add checkpoint-rbac.yaml**
This allows the kubectl checkpoint plugin to create the container checkpoint.

**Run curl with sudo in kubectl-checkpoint**
Previously, the curl command could not access the kubelet's client certificate and key.

**Update README.md with kubeadm instructions**

- Updated with specific instructions for kubeadm
- Added instruction to apply the RBAC manifest
- Updated the commands of step 9 to run as root
- Added a note that the local registry is optional