### PR TITLE
Fix building of custom container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ For more information about the project, please refer to the [final report](REPOR
     - [Prerequisites](#prerequisites)
     - [Install Python Dependencies](#install-python-dependencies)
     - [Installing PI](#installing-pi)
-    - [Build Custom Podman Images](#build-custom-podman-images)
   - [Running examples](#running-examples)
 
 
@@ -45,18 +44,6 @@ The p4 library files in your `.venv` will be owned by the root user. Make sure t
 ```bash
 sudo chown -R $USER .venv
 ``` 
-
-### Build Custom Podman Images
-```bash
-make images
-```
-This will build the following images:
-- `tcp-client`: A simple TCP client that sends a message to a server (this will run in h1-pod)
-- `tcp-server`: A simple TCP server that listens for a message from a client (this will run in all other pods)
-
-You can configure the target IP of the client and the port of the server in the [tcp/Containerfile.server](tcp/Containerfile.server) and [tcp/Containerfile.client](tcp/Containerfile.client) files respectively.
-
-Furthermore, you can specify which image to run in the hosts by changing the `IMG` and `ARGS` variables in [scripts/switch_container/build.sh](scripts/switch_container/build.sh).
 
 ## Running examples
 There are three examples in the `examples` directory:

--- a/examples/host_containers/Makefile
+++ b/examples/host_containers/Makefile
@@ -1,6 +1,6 @@
 include ../../utils/Makefile
 
-all: compile build controller
+all: images compile build controller
 
 terminals: h1 h2 h3 h4
 

--- a/examples/switch_container/Makefile
+++ b/examples/switch_container/Makefile
@@ -1,6 +1,6 @@
 include ../../utils/Makefile
 
-all: compile build controller
+all: images compile build controller
 
 terminals: h1 h2 h3 h4
 


### PR DESCRIPTION
- Added the `images` target to the `all` target of `host_containers` and `switch_container`
- Removed description of `make images` from the root README file which is not needed anymore