### PR TITLE
Remove "Build custom Podman images" from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ For more information about the project, please refer to the [final report](REPOR
   - [Installation](#installation)
     - [Prerequisites](#prerequisites)
     - [Install Python Dependencies](#install-python-dependencies)
-    - [Build Custom Podman Images](#build-custom-podman-images)
   - [Running examples](#running-examples)
 
 
@@ -24,9 +23,10 @@ For more information about the project, please refer to the [final report](REPOR
 - [P4 Compiler](https://github.com/p4lang/p4c) (v1.2.4.14)
 - [PI](https://github.com/p4lang/PI)
 - [Podman](https://podman.io/docs/installation) (v5.2.1)
+
 The versions mentioned above are the ones used during development. Newer versions may work, but have not been tested.
 
-We have provided [scripts](scripts) to install CRIU (with crit), the P4 compiler, PI, and Podman. The scripts have been tested on Ubuntu 22.04 and 24.04 and are not guaranteed to work on all machines. If you encounter any issues, please refer to the official documentation of the respective projects.
+We have provided [scripts](scripts) to install CRIU (with crit), the P4 compiler, PI, and Podman. The scripts have been tested on Ubuntu [22.04.4](https://releases.ubuntu.com/jammy/) and [24.04](https://releases.ubuntu.com/noble/) and are not guaranteed to work on all machines. If you encounter any issues, please refer to the official documentation of the respective projects.
 
 ### Install Python Dependencies
 ```bash
@@ -34,18 +34,6 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
-
-### Build Custom Podman Images
-```bash
-make images
-```
-This will build the following images:
-- `tcp-client`: A simple TCP client that sends a message to a server (this will run in h1-pod)
-- `tcp-server`: A simple TCP server that listens for a message from a client (this will run in all other pods)
-
-You can configure the target IP of the client and the port of the server in the [tcp/Containerfile.server](tcp/Containerfile.server) and [tcp/Containerfile.client](tcp/Containerfile.client) files respectively.
-
-Furthermore, you can specify which image to run in the hosts by changing the `IMG` and `ARGS` variables in [scripts/switch_container/build.sh](scripts/switch_container/build.sh).
 
 ## Running examples
 There are three examples in the `examples` directory:


### PR DESCRIPTION
This section is irrelevant, since we build the images when running `make` in the `examples`. Also, the root Makefile was moved to utils, so `make images`  is not a valid command in the root of the project anymore.

Other changes:
- Added links to Ubuntu versions
- Added a newline after the dependency list