### PR TITLE
Add installation scripts for k8s, correct PI installation

### DIFF
--- a/scripts/install_k8s.sh
+++ b/scripts/install_k8s.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Install kubelet, kubeadm, kubectl, and cri-o on Ubuntu 22.04+
+# Source: https://github.com/cri-o/packaging/blob/main/README.md#usage
+
+KUBERNETES_VERSION=v1.31
+CRIO_VERSION=v1.30
+
+sudo apt-get update
+# apt-transport-https may be a dummy package; if so, you can skip that package
+sudo apt-get install -y software-properties-common apt-transport-https ca-certificates curl gpg
+
+# If the directory `/etc/apt/keyrings` does not exist, it should be created before the curl command, read the note below.
+sudo mkdir -p -m 755 /etc/apt/keyrings
+
+curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key |
+    sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" |
+    sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/Release.key |
+    sudo gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/ /" |
+    sudo tee /etc/apt/sources.list.d/cri-o.list
+
+sudo apt-get update
+sudo apt-get install -y cri-o kubelet kubeadm kubectl
+sudo apt-mark hold kubelet kubeadm kubectl
+
+sudo systemctl enable --now kubelet
+sudo systemctl start crio.service
+
+# Swap should be disabled and br_netfilter should be loaded,
+# and net.ipv4.ip_forward should be enabled,
+# otherwise, kubeadm init will fail when starting kubelet.
+# sudo swapoff -a
+# sudo modprobe br_netfilter
+# sudo sysctl -w net.ipv4.ip_forward=1

--- a/scripts/install_pi.sh
+++ b/scripts/install_pi.sh
@@ -24,7 +24,7 @@ sudo apt-get install -y \
 
 pip3 install protobuf==3.20.0
 
-git clone --depth 1 --branch main https://github.com/p4lang/PI.git
+git clone https://github.com/p4lang/PI.git
 cd PI
 git checkout 05cb92564af77ae4826565cbde84e3fd4960c6bd
 git submodule update --init --recursive


### PR DESCRIPTION
- Added an installation script for Ubuntu 22.04+ for k8s (includes `cri-o`, `kubelet`, `kubeadm` and `kubectl`)
- Fixed `PI` installation script by removing `--branch main --depth 1` since in the next step we checkout a specific commit hash