### PR TITLE
Increase ecmp_nhop table size to 256

### DIFF
--- a/load_balancer/load_balance.p4
+++ b/load_balancer/load_balance.p4
@@ -151,7 +151,7 @@ control MyIngress(inout headers hdr,
             drop;
             set_nhop;
         }
-        size = 4;
+        size = 256;
     }
     apply {
         if (hdr.ipv4.isValid() && hdr.ipv4.ttl > 0) {


### PR DESCRIPTION
- Increased `ecmp_nhop` size to 256, to allow more than 4 nodes to be added